### PR TITLE
Re-export SyncTypingEvent

### DIFF
--- a/crates/ruma-client-api/src/sync/sync_events/v5.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v5.rs
@@ -458,9 +458,11 @@ impl Response {
 pub mod response {
     use ruma_common::OneTimeKeyAlgorithm;
     use ruma_events::{
-        receipt::SyncReceiptEvent, typing::SyncTypingEvent, AnyGlobalAccountDataEvent,
+        receipt::SyncReceiptEvent, AnyGlobalAccountDataEvent,
         AnyRoomAccountDataEvent, AnyToDeviceEvent,
     };
+
+    pub use ruma_events::typing::SyncTypingEvent
 
     use super::{
         super::DeviceLists, AnyStrippedStateEvent, AnySyncStateEvent, AnySyncTimelineEvent,


### PR DESCRIPTION
I'm planning to port the Typing indicator changes from continuwity and this is necessary for those.